### PR TITLE
AlltoAll & Fix the redundant division across gpus on kn input bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ wheelhouse/
 # Triton transpiler
 demo/mirage_search_checkpoint.json
 demo/*generated*
+demo/reference_mugraphs/*generated*

--- a/demo/reference_mugraphs/tb_alltoall.py
+++ b/demo/reference_mugraphs/tb_alltoall.py
@@ -17,17 +17,17 @@ if __name__ == "__main__":
     RANK = int(os.environ.get("RANK", 0))
     
     torch.cuda.set_device(RANK)
-    graph = mi.new_kernel_graph(gpu_dim=(2, 1, 1))
-    X = graph.new_input(dims=(64, 4096), gpu_input_map=(1, -1 ,-1), dtype=mi.float16)
-    W = graph.new_input(dims=(4096, 4096), gpu_input_map=(0, -1 ,-1), dtype=mi.float16)
-    tb_graph = mi.new_threadblock_graph(grid_dim=(64,1,1), block_dim=(128,1,1), forloop_range=64, reduction_dimx=64)
-    tX = tb_graph.new_input(dtensor=X, input_map=(-1, -1, -1), forloop_dim=1)
+    graph = mi.new_kernel_graph(gpu_dim=(4, 1, 1))
+    X = graph.new_input(dims=(512, 256), gpu_input_map=(1, -1 ,-1), dtype=mi.float16)
+    W = graph.new_input(dims=(256, 256), gpu_input_map=(0, -1 ,-1), dtype=mi.float16)
+    tb_graph = mi.new_threadblock_graph(grid_dim=(4,8,1), block_dim=(128,1,1), forloop_range=4, reduction_dimx=4)
+    tX = tb_graph.new_input(dtensor=X, input_map=(-1, 0, -1), forloop_dim=1)
     tW = tb_graph.new_input(dtensor=W, input_map=(1, -1, -1), forloop_dim=0)
     tM = tb_graph.matmul(tX, tW)
     tAccM = tb_graph.forloop_accum(tM)
 
-    #TB_ALLREDUCE_EPILOGUE
-    tb_graph.new_output(stensor=tAccM, output_map=(1, -1, -1), epilogue="allreduce")
+    #TB_ALLTOALL_EPILOGUE
+    tb_graph.new_output(stensor=tAccM, output_map=(0, 1, -1), epilogue="alltoall") # (0, 1, -1) right?
     O = graph.customized([X, W], tb_graph)
     graph.mark_output(O[0])
 
@@ -35,8 +35,8 @@ if __name__ == "__main__":
     print("Current rank: ", RANK)
     print("Current device: ", torch.cuda.current_device())
     input_tensors = [
-        torch.randn(64, 4096, dtype=torch.float16, device=torch.cuda.current_device()),
-        torch.randn(4096, 4096, dtype=torch.float16, device=torch.cuda.current_device()),
+        torch.randn(512, 256, dtype=torch.float16, device=torch.cuda.current_device()),
+        torch.randn(256, 256, dtype=torch.float16, device=torch.cuda.current_device()),
     ]
 
     outputs = graph(inputs=input_tensors, rank=RANK, save_codes=save_codes)

--- a/include/mirage/kernel/customized.h
+++ b/include/mirage/kernel/customized.h
@@ -40,6 +40,7 @@ public:
 public:
   mirage::threadblock::Graph bgraph;
   void get_bgraph(mirage::threadblock::Graph **bgraph);
+  std::vector<std::string> comm_buf_names; // buffer names for communication
 };
 
 } // namespace kernel

--- a/include/mirage/kernel/device_tensor.h
+++ b/include/mirage/kernel/device_tensor.h
@@ -133,6 +133,7 @@ public:
   static std::atomic<int64_t> next_guid;
 
   bool is_nvshmem_tensor = false;
+  type::TBEpilogueType epilogue = type::TBEpilogueType::TB_EPILOGUE_NONE;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(

--- a/include/mirage/kernel/graph.h
+++ b/include/mirage/kernel/graph.h
@@ -46,11 +46,17 @@ public:
                          int3 input_map,
                          mirage::type::DataType data_type,
                          mirage::layout::DmemLayout layout);
+  DTensor new_input_from_constructed(std::vector<int> const &dims,
+                    std::vector<size_t> const &strides,
+                    int3 input_map,
+                    mirage::type::DataType data_type,
+                    mirage::layout::DmemLayout layout);                      
   KNOperator *create_input_op(std::vector<int> const &dims,
                               std::vector<size_t> const &strides,
                               int3 input_map,
                               mirage::type::DataType data_type,
-                              mirage::layout::DmemLayout layout);
+                              mirage::layout::DmemLayout layout,
+                              bool dim_divided = false);
   // output operator
   void mark_output(DTensor const &A);
   void mark_output(DTensor const *A);

--- a/include/mirage/kernel/operator.h
+++ b/include/mirage/kernel/operator.h
@@ -60,7 +60,8 @@ public:
             std::vector<size_t> const &strides,
             mirage::type::DataType data_type,
             mirage::layout::DmemLayout layout,
-            int3 input_map = {-1, -1, -1});
+            int3 input_map = {-1, -1, -1},
+            bool dim_divided = false);
   ~KNInputOp();
   bool profile(ProfileResult &profile);
   bool fingerprint(void);

--- a/include/mirage/transpiler/runtime/nvshmem.h
+++ b/include/mirage/transpiler/runtime/nvshmem.h
@@ -40,6 +40,7 @@ static inline void finalize_mpi_nvshmem() {
 template <typename T>
 static inline T *to_nvshmem_ptr(std::size_t num_elements) {
 #if USE_NVSHMEM
+  //TODO: Northman
   void *ptr = nvshmem_malloc(num_elements * sizeof(T));
   return static_cast<T *>(nvshmem_ptr(ptr, nvshmem_my_pe()));
 #else

--- a/include/mirage/transpiler/transpiler.h
+++ b/include/mirage/transpiler/transpiler.h
@@ -54,10 +54,11 @@ private:
                     // distributed across nodes)
   void resolve_distributed_config() {
     num_gpus = g->gpu_dim.x * g->gpu_dim.y * g->gpu_dim.z;
-    // TODO (linsj20)
+    // TODO (linsj20) Logic to decide NCCL/NVSHMEM
     use_nccl = num_gpus > 1;
     use_nvshmem = num_gpus > 1;
-    use_nvshmem = false;
+    // use_nvshmem = false;
+    use_nccl = false;
   }
 
   // Tensor metadata

--- a/python/mirage/_cython/core.pyx
+++ b/python/mirage/_cython/core.pyx
@@ -248,6 +248,8 @@ def string_to_tbepilogue(epilogue):
         return TB_EPILOGUE_NONE
     elif epilogue == "allreduce":
         return TB_EPILOGUE_ALLREDUCE
+    elif epilogue == "alltoall":
+        return TB_EPILOGUE_ALLTOALL
     else:
         assert False, "Unsupported threadblock epilogue"
         return None

--- a/python/mirage/threadblock.py
+++ b/python/mirage/threadblock.py
@@ -3,11 +3,14 @@ from .core import *
 class TBGraph:
     def __init__(self, graph):
         self.cygraph = graph
+        self.use_nvshmem = False
 
     def new_input(self, dtensor: DTensor, input_map: tuple, forloop_dim: int):
         return self.cygraph.new_input(dtensor, input_map, forloop_dim)
 
     def new_output(self, stensor: STensor, output_map: tuple, forloop_dim: int = -1, epilogue: str = None):
+        if epilogue == "allreduce" or epilogue == "alltoall":
+            self.use_nvshmem = True
         return self.cygraph.new_output(stensor, output_map, forloop_dim, epilogue)
 
     def matmul(self, A: STensor, B: STensor):

--- a/src/kernel/customized.cc
+++ b/src/kernel/customized.cc
@@ -145,8 +145,10 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
         dtensor.owner_op = this;
         dtensor.owner_ts_idx = static_cast<int>(output_tensors.size());
         dtensor.guid = DTensor::next_guid++;
+        dtensor.epilogue = output_op->epilogue;
         dtensor.is_nvshmem_tensor =
-            output_op->epilogue == mirage::type::TB_EPILOGUE_ALLREDUCE;
+            (output_op->epilogue == mirage::type::TB_EPILOGUE_ALLREDUCE ||
+             output_op->epilogue == mirage::type::TB_EPILOGUE_ALLTOALL);
         // DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
         // dmm->allocate(dtensor);
         kgraph->allocate(dtensor);

--- a/src/kernel/input.cc
+++ b/src/kernel/input.cc
@@ -42,11 +42,24 @@ DTensor *Graph::new_input_ptr(std::vector<int> const &dims,
   return &op->output_tensors[0];
 }
 
+// For the case where the tensor has been divided during construction. Avoid redundant division.
+DTensor Graph::new_input_from_constructed(std::vector<int> const &dims,
+                         std::vector<size_t> const &strides,
+                         int3 input_map,
+                         mirage::type::DataType data_type,
+                         mirage::layout::DmemLayout layout) {
+  KNOperator *op = create_input_op(dims, strides, input_map, data_type, layout, true);
+  assert(op != nullptr);
+  operators.push_back(op);
+  return op->output_tensors[0];
+}
+
 KNOperator *Graph::create_input_op(std::vector<int> const &dims,
                                    std::vector<size_t> const &strides,
                                    int3 input_map,
                                    mirage::type::DataType data_type,
-                                   mirage::layout::DmemLayout layout) {
+                                   mirage::layout::DmemLayout layout,
+                                   bool dim_divided) {
   DTensor tensor;
   tensor.layout = layout;
   tensor.num_dims = dims.size();
@@ -56,7 +69,7 @@ KNOperator *Graph::create_input_op(std::vector<int> const &dims,
   tensor.data_type = data_type;
 
   KNInputOp *op =
-      new KNInputOp(this, dims, strides, data_type, layout, input_map);
+      new KNInputOp(this, dims, strides, data_type, layout, input_map, dim_divided);
 
   if (!can_allocate(op->output_tensors[0])) {
     return nullptr;
@@ -69,7 +82,8 @@ KNInputOp::KNInputOp(Graph *_graph,
                      std::vector<size_t> const &strides,
                      mirage::type::DataType data_type,
                      mirage::layout::DmemLayout layout,
-                     int3 _input_map)
+                     int3 _input_map,
+                     bool dim_divided)
     : KNOperator(_graph, mirage::type::KN_INPUT_OP), input_strides(strides),
       input_map(_input_map) {
   DTensor tensor;
@@ -78,26 +92,30 @@ KNInputOp::KNInputOp(Graph *_graph,
     tensor.dim[i] = dims[i];
   }
 
-  for (int d = 0; d < 3; d++) {
-    int dim_idx = -1;
-    int dim_div = 1;
-    if (d == 0 && kgraph->gpu_dim.x > 1) {
-      dim_idx = input_map.x;
-      dim_div = kgraph->gpu_dim.x;
-    }
-    if (d == 1 && kgraph->gpu_dim.y > 1) {
-      dim_idx = input_map.y;
-      dim_div = kgraph->gpu_dim.y;
-    }
-    if (d == 2 && kgraph->gpu_dim.z > 1) {
-      dim_idx = input_map.z;
-      dim_div = kgraph->gpu_dim.z;
-    }
+  if(!dim_divided) { // The tensor has been divided during construction. Avoid redundant division.
+    for (int d = 0; d < 3; d++) {
+      int dim_idx = -1;
+      int dim_div = 1;
+      if (d == 0 && kgraph->gpu_dim.x > 1) {
+        dim_idx = input_map.x;
+        dim_div = kgraph->gpu_dim.x;
+      }
+      if (d == 1 && kgraph->gpu_dim.y > 1) {
+        dim_idx = input_map.y;
+        dim_div = kgraph->gpu_dim.y;
+      }
+      if (d == 2 && kgraph->gpu_dim.z > 1) {
+        dim_idx = input_map.z;
+        dim_div = kgraph->gpu_dim.z;
+      }
 
-    if (dim_idx >= 0) {
-      assert(tensor.dim[dim_idx] > 0);
-      assert(tensor.dim[dim_idx] % dim_div == 0);
-      tensor.dim[dim_idx] /= dim_div;
+      if (dim_idx >= 0) {
+        printf("d=%d:    dim_idx: %d, dim_div: %d, tensor.dim[%d]: %d\n", d, dim_idx, dim_div, dim_idx, tensor.dim[dim_idx]);
+        assert(tensor.dim[dim_idx] > 0);
+        assert(tensor.dim[dim_idx] % dim_div == 0);
+        tensor.dim[dim_idx] /= dim_div;
+        printf("After: tensor.dim[%d]: %d\n", dim_idx, tensor.dim[dim_idx]);
+      }
     }
   }
 

--- a/src/threadblock/output.cc
+++ b/src/threadblock/output.cc
@@ -99,6 +99,8 @@ TBOutputOp::TBOutputOp(Graph *_graph,
   if (forloop_dim >= 0) {
     dtensor.dim[forloop_dim] *= bgraph->forloop_range;
   }
+
+  dtensor.epilogue = epilogue;
 }
 
 TBOutputOp::~TBOutputOp() {

--- a/src/transpiler/transpile.cc
+++ b/src/transpiler/transpile.cc
@@ -69,7 +69,7 @@ Transpiler::Transpiler(kernel::Graph const *_graph,
         // defined in mugraph
         assert(input_dtensor_idx < (int)input_strides.size());
         assert(input_op->input_strides == input_strides[input_dtensor_idx++]);
-        kernel::DTensor dt = g->new_input(dims,
+        kernel::DTensor dt = g->new_input_from_constructed(dims,
                                           input_op->input_strides,
                                           input_op->input_map,
                                           dtensor.data_type,


### PR DESCRIPTION
**Description of changes:**
1. Add new_input_from_constructed() to minimize code change and tell the input builder not to divide dims again.
2. Initialize AlltoAll transpiler part logic
3. Remaining bug: meta.stride wrongly calculated under multi-GPU situation



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


