### PR TITLE
Support multiple combinations of matmul_hopper params

### DIFF
--- a/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
@@ -33,12 +33,13 @@ using bfloat16 = type::bfloat16_t;
 // a 64X64X4K kernel for reference
 template <typename T,
           int BATCH_SIZE,
-          int HIDDEN_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
           int Kstages,
           typename TMA_A,
           typename TMA_B,
           typename TMA_OUT,
-          int OUTPUT_STRIDE = 64>
+          int OUTPUT_STRIDE = OUTPUT_SIZE>
 __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
                                                      const TMA_A &tma_a,
                                                      const TMA_B &tma_b,
@@ -51,9 +52,9 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
   constexpr int NUM_WARPGROUPS = CONSUMER_WARPGROUPS + PRODUCER_WARPGROUPS;
 
   // using SM90_64x64x16_F16F16F16F32
-  constexpr int num_n = HIDDEN_SIZE / 64;
+  constexpr int num_n = OUTPUT_SIZE / 64;
   constexpr int num_m = BATCH_SIZE / 64;
-  constexpr int num_k = HIDDEN_SIZE / 64;
+  constexpr int num_k = REDUCTION_SIZE / 64;
   int warp_idx = warp_id();
   int idx_in_warp = threadIdx.x % 32;
   int warpgroup_id = warp_idx / WARPGROUP_WARPS;

--- a/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
@@ -45,27 +45,27 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
                                                      const TMA_B &tma_b,
                                                      const TMA_OUT &tma_out) {
   constexpr int chunk_size = 16 / sizeof(T);
-  constexpr int TILE_SIZE = 64;
+  constexpr int TILE_SIZE = 16;
   constexpr int THREADS_PER_WARPGROUP = 128;
   constexpr int CONSUMER_WARPGROUPS = 1;
   constexpr int PRODUCER_WARPGROUPS = 1;
   constexpr int NUM_WARPGROUPS = CONSUMER_WARPGROUPS + PRODUCER_WARPGROUPS;
-  
+
   constexpr int TMA_TRANS_BYTES_A = sizeof(T) * BATCH_SIZE * TILE_SIZE;
-  constexpr int TMA_TRANS_BYTES_B = sizeof(T) * TILE_SIZE * TILE_SIZE;
+  constexpr int TMA_TRANS_BYTES_B = sizeof(T) * TILE_SIZE * OUTPUT_SIZE;
   constexpr int TMA_TRANS_BYTES_OUT = sizeof(T) * BATCH_SIZE * TILE_SIZE;
 
   // using SM90_64x64x16_F16F16F16F32
   constexpr int num_n = OUTPUT_SIZE / 64;
   constexpr int num_m = BATCH_SIZE / 64;
-  constexpr int num_k = REDUCTION_SIZE / 64;
+  constexpr int num_k = REDUCTION_SIZE / TILE_SIZE;
   int warp_idx = warp_id();
   int idx_in_warp = threadIdx.x % 32;
   int warpgroup_id = warp_idx / WARPGROUP_WARPS;
 
   T __restrict__ *d_output = static_cast<T *>(output_ptr);
 
-  dmem_row<T, 64, 64, 64> output_dmem(d_output);
+  dmem_row<T, BATCH_SIZE, OUTPUT_SIZE, OUTPUT_SIZE> output_dmem(d_output);
 
   extern __shared__ char smem[];
 
@@ -88,18 +88,19 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
   // out
 
   // define the swizzle mode
-  using InputSmem = smem_row<T, 0, 0, 0, 64, 64, 64>;
+  using InputSmem = smem_row<T, 0, 4, 3, BATCH_SIZE, TILE_SIZE, TILE_SIZE>;
   InputSmem input_smem(shared_input);
   InputSmem input_smem_buffer(shared_input);
 
-  using WeightSmem = smem_col<T, 0, 0, 0, 64, 64, 64>;
+  using WeightSmem = smem_col<T, 0, 4, 3, TILE_SIZE, OUTPUT_SIZE, TILE_SIZE>;
   WeightSmem input_weight_smem(shared_weight);
   WeightSmem input_weight_smem_buffer(shared_weight);
 
   using A_DESC = wgmma::mma_descriptor<InputSmem>;
   using B_DESC = wgmma::mma_descriptor<WeightSmem>;
 
-  smem_row<T, 0, 0, 0, 64, 64, 64> mm_output_smem(mm_output);
+  smem_row<T, 0, 0, 0, BATCH_SIZE, OUTPUT_SIZE, OUTPUT_SIZE> mm_output_smem(
+      mm_output);
   float s_frag[32];
 
 #pragma unroll
@@ -123,28 +124,6 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
 
   __syncthreads();
 
-  // if (threadIdx.x == 0) {
-  //   // launch the first group of copy
-  //   for (int i = 0; i < Kstages - 1; i++) {
-  //     // int4 tma_coords = {0, 0, 0, 0};
-  //     int2 tma_coords_A = {0, i};
-  //     int2 tma_coords_B = {0, i};
-  //     // sizeof(T) * TILE_SIZE * TILE_SIZE = 8192
-  //     set_barrier_transaction_bytes(input_barrier[i], 8192);
-  //     tma_a.tma_cp_async(
-  //         input_barrier[i], input_smem_buffer(0, 0), tma_coords_A);
-  //     set_barrier_transaction_bytes(weight_barrier[i], 8192);
-  //     tma_b.tma_cp_async(
-  //         weight_barrier[i], input_weight_smem_buffer(0, 0), tma_coords_B);
-  //     // mv smem ptr to next buffer
-  //     // sizeof(T) * TILE_SIZE * TILE_SIZE = 8192
-  //     input_smem_buffer.set_ptr(shared_input + (i + 1) % Kstages * 8192);
-  //     input_weight_smem_buffer.set_ptr(shared_weight + (i + 1) % Kstages * 8192);
-  //   }
-  // }
-
-  __syncthreads();
-
   // warp specialization data movement warpgroup
   if (warpgroup_id == NUM_WARPGROUPS - 1) {
 
@@ -152,24 +131,28 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
     if (lane_id() == 0 && warp_idx == (NUM_WARPGROUPS * WARPGROUP_WARPS - 4)) {
       for (int i = 0; i < num_k; i++) {
         // get cord, copy
-        int2 tma_coords_A = {i*TILE_SIZE, 0};
-        int2 tma_coords_B = {i*TILE_SIZE, 0};
-        set_barrier_transaction_bytes(input_barrier[(i) % Kstages], 8192);
+        int2 tma_coords_A = {i * TILE_SIZE, 0};
+        int2 tma_coords_B = {i * TILE_SIZE, 0};
+        set_barrier_transaction_bytes(input_barrier[(i) % Kstages],
+                                      TMA_TRANS_BYTES_A);
         tma_a.tma_cp_async(input_barrier[(i) % Kstages],
                            input_smem_buffer(0, 0),
                            tma_coords_A);
-        set_barrier_transaction_bytes(weight_barrier[(i) % Kstages], 8192);
+        set_barrier_transaction_bytes(weight_barrier[(i) % Kstages],
+                                      TMA_TRANS_BYTES_B);
 
         tma_b.tma_cp_async(weight_barrier[(i) % Kstages],
                            input_weight_smem_buffer(0, 0),
                            tma_coords_B);
 
-        wait(compute_done[(i+1) % Kstages], ((i+1+Kstages) / Kstages) % Kstages);
+        wait(compute_done[(i + 1) % Kstages],
+             ((i + 1 + Kstages) / Kstages) % Kstages);
 
-        input_smem_buffer.set_ptr(shared_input +
-                                  ((i+1) % Kstages) * 8192 / 2);
-        input_weight_smem_buffer.set_ptr(shared_weight +
-                                         ((i+1) % Kstages) * 8192 / 2);
+        input_smem_buffer.set_ptr(
+            shared_input + ((i + 1) % Kstages) * TMA_TRANS_BYTES_A / sizeof(T));
+        input_weight_smem_buffer.set_ptr(shared_weight + ((i + 1) % Kstages) *
+                                                             TMA_TRANS_BYTES_B /
+                                                             sizeof(T));
       }
     }
   } else {
@@ -181,25 +164,24 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
       wait(weight_barrier[i % Kstages], ((i / Kstages) % Kstages));
 
       input_smem.set_ptr(shared_input +
-                          ((i) % Kstages) * 8192 / 2);
-      input_weight_smem.set_ptr(shared_weight +
-                                        ((i) % Kstages) * 8192 / 2);
+                         ((i) % Kstages) * TMA_TRANS_BYTES_A / sizeof(T));
+      input_weight_smem.set_ptr(
+          shared_weight + ((i) % Kstages) * TMA_TRANS_BYTES_B / sizeof(T));
 
       if (threadIdx.x == 0) {
         printf("i: %d\n", i);
         printf("input_smem ptr: %p\n", input_smem(0, 0));
         printf("input_weight_smem ptr: %p\n", input_weight_smem(0, 0));
         printf("input_smem\n");
-        for (int j = 0; j < 64; j++) {
-          for (int k = 0; k < 64; k++) {
+        for (int j = 0; j < BATCH_SIZE; j++) {
+          for (int k = 0; k < TILE_SIZE; k++) {
             printf("%f ", (float)input_smem.at(j, k));
-            
           }
           printf("\n");
         }
         printf("input_weight_smem\n");
-        for (int j = 0; j < 64; j++) {
-          for (int k = 0; k < 64; k++) {
+        for (int j = 0; j < OUTPUT_SIZE; j++) {
+          for (int k = 0; k < TILE_SIZE; k++) {
             printf("%f ", (float)input_weight_smem.at(j, k));
           }
           printf("\n");
@@ -239,9 +221,15 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
       mm_output_smem.at(row, col) = bfloat16(s_frag[i * 2]);
       mm_output_smem.at(row, col + 1) = bfloat16(s_frag[i * 2 + 1]);
 
-      if (threadIdx.x == 28) {
-        printf("mm_output_smem.at(%d, %d) = %f\n", row, col, (float)mm_output_smem.at(row, col));
-        printf("mm_output_smem.at(%d, %d) = %f\n", row, col + 1, (float)mm_output_smem.at(row, col + 1));
+      if (threadIdx.x == 8) {
+        printf("mm_output_smem.at(%d, %d) = %f\n",
+               row,
+               col,
+               (float)mm_output_smem.at(row, col));
+        printf("mm_output_smem.at(%d, %d) = %f\n",
+               row,
+               col + 1,
+               (float)mm_output_smem.at(row, col + 1));
       }
     }
 
@@ -252,6 +240,16 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
     // this is inter-thread sync
     wg_sync<THREADS_PER_WARPGROUP * CONSUMER_WARPGROUPS>(8);
 
+    //  if (threadIdx.x == 0) {
+    //    printf("mm_output_smem\n");
+    //    for (int j = 0; j < BATCH_SIZE; j++) {
+    //      for (int k = 0; k < OUTPUT_SIZE; k++) {
+    //        printf("%f ", (float)mm_output_smem.at(j, k));
+    //      }
+    //      printf("\n");
+    //    }
+    //  }
+
     // copy back to dmem
     if (warp_idx % 4 == 0 && lane_id() == 0) {
       tma_out.tma_store_async(mm_output_smem(0, 0), {0, 0});
@@ -259,6 +257,16 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
     }
     store_async_wait<0>();
     wg_sync<THREADS_PER_WARPGROUP * CONSUMER_WARPGROUPS>(8);
+
+    if (threadIdx.x == 0) {
+      printf("mm_output_gmem\n");
+      for (int j = 0; j < BATCH_SIZE; j++) {
+        for (int k = 0; k < OUTPUT_SIZE; k++) {
+          printf("%f ", (float)output_dmem.at(j, k));
+        }
+        printf("\n");
+      }
+    }
   }
 }
 

--- a/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
@@ -168,25 +168,25 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
       input_weight_smem.set_ptr(
           shared_weight + ((i) % Kstages) * TMA_TRANS_BYTES_B / sizeof(T));
 
-      if (threadIdx.x == 0) {
-        printf("i: %d\n", i);
-        printf("input_smem ptr: %p\n", input_smem(0, 0));
-        printf("input_weight_smem ptr: %p\n", input_weight_smem(0, 0));
-        printf("input_smem\n");
-        for (int j = 0; j < BATCH_SIZE; j++) {
-          for (int k = 0; k < TILE_SIZE; k++) {
-            printf("%f ", (float)input_smem.at(j, k));
-          }
-          printf("\n");
-        }
-        printf("input_weight_smem\n");
-        for (int j = 0; j < OUTPUT_SIZE; j++) {
-          for (int k = 0; k < TILE_SIZE; k++) {
-            printf("%f ", (float)input_weight_smem.at(j, k));
-          }
-          printf("\n");
-        }
-      }
+      // if (threadIdx.x == 0) {
+      //   printf("i: %d\n", i);
+      //   printf("input_smem ptr: %p\n", input_smem(0, 0));
+      //   printf("input_weight_smem ptr: %p\n", input_weight_smem(0, 0));
+      //   printf("input_smem\n");
+      //   for (int j = 0; j < BATCH_SIZE; j++) {
+      //     for (int k = 0; k < TILE_SIZE; k++) {
+      //       printf("%f ", (float)input_smem.at(j, k));
+      //     }
+      //     printf("\n");
+      //   }
+      //   printf("input_weight_smem\n");
+      //   for (int j = 0; j < OUTPUT_SIZE; j++) {
+      //     for (int k = 0; k < TILE_SIZE; k++) {
+      //       printf("%f ", (float)input_weight_smem.at(j, k));
+      //     }
+      //     printf("\n");
+      //   }
+      // }
 
       A_DESC a_desc(input_smem(0, 0));
       B_DESC b_desc(input_weight_smem(0, 0));
@@ -221,16 +221,16 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
       mm_output_smem.at(row, col) = bfloat16(s_frag[i * 2]);
       mm_output_smem.at(row, col + 1) = bfloat16(s_frag[i * 2 + 1]);
 
-      if (threadIdx.x == 8) {
-        printf("mm_output_smem.at(%d, %d) = %f\n",
-               row,
-               col,
-               (float)mm_output_smem.at(row, col));
-        printf("mm_output_smem.at(%d, %d) = %f\n",
-               row,
-               col + 1,
-               (float)mm_output_smem.at(row, col + 1));
-      }
+      // if (threadIdx.x == 8) {
+      //   printf("mm_output_smem.at(%d, %d) = %f\n",
+      //          row,
+      //          col,
+      //          (float)mm_output_smem.at(row, col));
+      //   printf("mm_output_smem.at(%d, %d) = %f\n",
+      //          row,
+      //          col + 1,
+      //          (float)mm_output_smem.at(row, col + 1));
+      // }
     }
 
     // make sure generic proxy's modification to smem is visible to tma store
@@ -258,15 +258,15 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
     store_async_wait<0>();
     wg_sync<THREADS_PER_WARPGROUP * CONSUMER_WARPGROUPS>(8);
 
-    if (threadIdx.x == 0) {
-      printf("mm_output_gmem\n");
-      for (int j = 0; j < BATCH_SIZE; j++) {
-        for (int k = 0; k < OUTPUT_SIZE; k++) {
-          printf("%f ", (float)output_dmem.at(j, k));
-        }
-        printf("\n");
-      }
-    }
+    // if (threadIdx.x == 0) {
+    //   printf("mm_output_gmem\n");
+    //   for (int j = 0; j < BATCH_SIZE; j++) {
+    //     for (int k = 0; k < OUTPUT_SIZE; k++) {
+    //       printf("%f ", (float)output_dmem.at(j, k));
+    //     }
+    //     printf("\n");
+    //   }
+    // }
   }
 }
 

--- a/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/matmul_demo_hopper.cuh
@@ -177,7 +177,7 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
     // wg_increase_regs<160>();
     for (int i = 0; i < num_k; i++) {
       // wait input, weight
-      // wait(input_barrier[i % Kstages], ((i / Kstages) % Kstages));
+      wait(input_barrier[i % Kstages], ((i / Kstages) % Kstages));
       wait(weight_barrier[i % Kstages], ((i / Kstages) % Kstages));
 
       input_smem.set_ptr(shared_input +
@@ -239,7 +239,7 @@ __device__ __forceinline__ void linear_kernel_hopper(void *output_ptr,
       mm_output_smem.at(row, col) = bfloat16(s_frag[i * 2]);
       mm_output_smem.at(row, col + 1) = bfloat16(s_frag[i * 2 + 1]);
 
-      if (threadIdx.x == 8) {
+      if (threadIdx.x == 28) {
         printf("mm_output_smem.at(%d, %d) = %f\n", row, col, (float)mm_output_smem.at(row, col));
         printf("mm_output_smem.at(%d, %d) = %f\n", row, col + 1, (float)mm_output_smem.at(row, col + 1));
       }

--- a/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
@@ -66,6 +66,10 @@ public:
     uint32_t smem_int_ptr =
         static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
 
+    if (threadIdx.x == 128 && threadIdx.y == 0 && threadIdx.z == 0) {
+      printf("tma_cp_async: crd0: %d, crd1: %d", tma_coords.x, tma_coords.y);
+    }
+
     asm volatile("cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier:"
                  ":complete_tx::bytes"
                  " [%0], [%1, {%3, %4, %5, %6, %7}], [%2];"

--- a/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
@@ -66,9 +66,9 @@ public:
     uint32_t smem_int_ptr =
         static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
 
-    if (threadIdx.x == 128 && threadIdx.y == 0 && threadIdx.z == 0) {
-      printf("tma_cp_async: crd0: %d, crd1: %d", tma_coords.x, tma_coords.y);
-    }
+    // if (threadIdx.x == 128 && threadIdx.y == 0 && threadIdx.z == 0) {
+    //   printf("tma_cp_async: crd0: %d, crd1: %d", tma_coords.x, tma_coords.y);
+    // }
 
     asm volatile("cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier:"
                  ":complete_tx::bytes"

--- a/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/tma.cuh
@@ -134,7 +134,7 @@ private:
     //             : CU_TENSOR_MAP_SWIZZLE_NONE);
     //  constexpr CUtensorMapSwizzle tma_swizzle = CU_TENSOR_MAP_SWIZZLE_NONE;
 
-//     printf("GMEM_ROW: %zu, GMEM_COL: %zu\n", GMEM_ROW, GMEM_COL);
+    //     printf("GMEM_ROW: %zu, GMEM_COL: %zu\n", GMEM_ROW, GMEM_COL);
 
     uint64_t gmem_shape[5] = {GMEM_COL, GMEM_ROW, 1, 1, 1};
     uint64_t gmem_prob_stride[5] = {sizeof(T), GMEM_COL * sizeof(T), 0, 0, 0};
@@ -146,55 +146,62 @@ private:
     uint32_t const *smem_box_shape_ptr = &smem_box_shape[0];
     uint32_t const *smem_box_stride_ptr = &smem_box_stride[0];
 
-// //     TMA descriptor does not store the zeroth stride and assumes it is 1 (TmaInternalType element).
-//     assert(gmem_prob_stride[0] == 1 && "Majorness of smem doesn't match majorness of gmem");
+    // //     TMA descriptor does not store the zeroth stride and assumes it is
+    // 1 (TmaInternalType element).
+    //     assert(gmem_prob_stride[0] == 1 && "Majorness of smem doesn't match
+    //     majorness of gmem");
 
-//     // ensure that the global address is always 16-byte aligned
-//     assert((reinterpret_cast<uint64_t>(global_addr) & 0b1111) == 0);
+    //     // ensure that the global address is always 16-byte aligned
+    //     assert((reinterpret_cast<uint64_t>(global_addr) & 0b1111) == 0);
 
-//     assert((gmem_prob_stride[1]) <
-//            (uint64_t(1) << 40)); // Stride must be max 2^40
-//     assert((gmem_prob_stride[1] & 0b1111) ==
-//            0); // Stride must be multiple of 16B (128b)
-//     assert((gmem_prob_stride[2]) <
-//            (uint64_t(1) << 40)); // Stride must be max 2^40
-//     assert((gmem_prob_stride[2] & 0b1111) ==
-//            0); // Stride must be multiple of 16B (128b)
-//     assert((gmem_prob_stride[3]) <
-//            (uint64_t(1) << 40)); // Stride must be max 2^40
-//     assert((gmem_prob_stride[3] & 0b1111) ==
-//            0); // Stride must be multiple of 16B (128b)
-//     assert((gmem_prob_stride[4]) <
-//            (uint64_t(1) << 40)); // Stride must be max 2^40
-//     assert((gmem_prob_stride[4] & 0b1111) ==
-//            0); // Stride must be multiple of 16B (128b)
+    //     assert((gmem_prob_stride[1]) <
+    //            (uint64_t(1) << 40)); // Stride must be max 2^40
+    //     assert((gmem_prob_stride[1] & 0b1111) ==
+    //            0); // Stride must be multiple of 16B (128b)
+    //     assert((gmem_prob_stride[2]) <
+    //            (uint64_t(1) << 40)); // Stride must be max 2^40
+    //     assert((gmem_prob_stride[2] & 0b1111) ==
+    //            0); // Stride must be multiple of 16B (128b)
+    //     assert((gmem_prob_stride[3]) <
+    //            (uint64_t(1) << 40)); // Stride must be max 2^40
+    //     assert((gmem_prob_stride[3] & 0b1111) ==
+    //            0); // Stride must be multiple of 16B (128b)
+    //     assert((gmem_prob_stride[4]) <
+    //            (uint64_t(1) << 40)); // Stride must be max 2^40
+    //     assert((gmem_prob_stride[4] & 0b1111) ==
+    //            0); // Stride must be multiple of 16B (128b)
 
-//     assert(smem_box_shape[0] >= (uint32_t(1))); // Size must be min 1
-//     assert(smem_box_shape[0] <=
-//            (uint32_t(1) << 8));                 // Size must be max 2^8 = 256
-//     assert(smem_box_shape[1] >= (uint32_t(1))); // Size must be min 1
-//     assert(smem_box_shape[1] <=
-//            (uint32_t(1) << 8));                 // Size must be max 2^8 = 256
-//     assert(smem_box_shape[2] >= (uint32_t(1))); // Size must be min 1
-//     assert(smem_box_shape[2] <=
-//            (uint32_t(1) << 8));                 // Size must be max 2^8 = 256
-//     assert(smem_box_shape[3] >= (uint32_t(1))); // Size must be min 1
-//     assert(smem_box_shape[3] <=
-//            (uint32_t(1) << 8));                 // Size must be max 2^8 = 256
-//     assert(smem_box_shape[4] >= (uint32_t(1))); // Size must be min 1
-//     assert(smem_box_shape[4] <=
-//            (uint32_t(1) << 8)); // Size must be max 2^8 = 256
+    //     assert(smem_box_shape[0] >= (uint32_t(1))); // Size must be min 1
+    //     assert(smem_box_shape[0] <=
+    //            (uint32_t(1) << 8));                 // Size must be max 2^8 =
+    //            256
+    //     assert(smem_box_shape[1] >= (uint32_t(1))); // Size must be min 1
+    //     assert(smem_box_shape[1] <=
+    //            (uint32_t(1) << 8));                 // Size must be max 2^8 =
+    //            256
+    //     assert(smem_box_shape[2] >= (uint32_t(1))); // Size must be min 1
+    //     assert(smem_box_shape[2] <=
+    //            (uint32_t(1) << 8));                 // Size must be max 2^8 =
+    //            256
+    //     assert(smem_box_shape[3] >= (uint32_t(1))); // Size must be min 1
+    //     assert(smem_box_shape[3] <=
+    //            (uint32_t(1) << 8));                 // Size must be max 2^8 =
+    //            256
+    //     assert(smem_box_shape[4] >= (uint32_t(1))); // Size must be min 1
+    //     assert(smem_box_shape[4] <=
+    //            (uint32_t(1) << 8)); // Size must be max 2^8 = 256
 
-//     assert(smem_box_stride[0] >= (uint32_t(1))); // Stride must be min 1
-//     assert(smem_box_stride[0] <= (uint32_t(8))); // Stride must be max 2^3 = 8
-//     assert(smem_box_stride[1] >= (uint32_t(1))); // Stride must be min 1
-//     assert(smem_box_stride[1] <= (uint32_t(8))); // Stride must be max 2^3 = 8
-//     assert(smem_box_stride[2] >= (uint32_t(1))); // Stride must be min 1
-//     assert(smem_box_stride[2] <= (uint32_t(8))); // Stride must be max 2^3 = 8
-//     assert(smem_box_stride[3] >= (uint32_t(1))); // Stride must be min 1
-//     assert(smem_box_stride[3] <= (uint32_t(8))); // Stride must be max 2^3 = 8
-//     assert(smem_box_stride[4] >= (uint32_t(1))); // Stride must be min 1
-//     assert(smem_box_stride[4] <= (uint32_t(8))); // Stride must be max 2^3 = 8
+    //     assert(smem_box_stride[0] >= (uint32_t(1))); // Stride must be min 1
+    //     assert(smem_box_stride[0] <= (uint32_t(8))); // Stride must be max
+    //     2^3 = 8 assert(smem_box_stride[1] >= (uint32_t(1))); // Stride must
+    //     be min 1 assert(smem_box_stride[1] <= (uint32_t(8))); // Stride must
+    //     be max 2^3 = 8 assert(smem_box_stride[2] >= (uint32_t(1))); // Stride
+    //     must be min 1 assert(smem_box_stride[2] <= (uint32_t(8))); // Stride
+    //     must be max 2^3 = 8 assert(smem_box_stride[3] >= (uint32_t(1))); //
+    //     Stride must be min 1 assert(smem_box_stride[3] <= (uint32_t(8))); //
+    //     Stride must be max 2^3 = 8 assert(smem_box_stride[4] >=
+    //     (uint32_t(1))); // Stride must be min 1 assert(smem_box_stride[4] <=
+    //     (uint32_t(8))); // Stride must be max 2^3 = 8
 
     CUresult result = cuTensorMapEncodeTiled(tma_desc,
                                              tma_format,
@@ -225,7 +232,6 @@ private:
                 << std::endl;
       assert(false);
     }
-
   }
 };
 // cutlass/include/cute/atom/copy_traits_sm90_tma.hpp

--- a/include/mirage/persistent_kernel/tasks/hopper/wgmma.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/wgmma.cuh
@@ -45,36 +45,10 @@ struct mma_descriptor {
         base_desc |= matrix_descriptor_encode((uint64_t)256) << 32;
         base_desc |= 3llu << 62; // set wgmma_swizzle mode
       } else {
-        // 64*2
         base_desc |= matrix_descriptor_encode((uint64_t)16) << 16;
-        // 一个core matrix有8*8=64个元素，沿着k有 A_COL/8个core matrix
-        // 不是A_COL而是64，因为切块smem k为64
-        // sbo = 64*64/8 * 2 bytes
-        // = 64 * 64 / 4
         base_desc |= matrix_descriptor_encode((uint64_t)256) << 32;
         base_desc |= 0llu << 62; // set wgmma_swizzle mode
       }
-    } else {
-      // if constexpr (SMEM::b == 3) {
-      //       base_desc |= matrix_descriptor_encode((uint64_t)2048*ST::height)
-      //       << 16; base_desc |= matrix_descriptor_encode((uint64_t)1024) <<
-      //       32; base_desc |= 1llu << 62; // set wgmma_swizzle mode
-      //   }
-      //   else if constexpr (SMEM::b == 2) {
-      //       base_desc |= matrix_descriptor_encode((uint64_t)1024*ST::height)
-      //       << 16; base_desc |= matrix_descriptor_encode((uint64_t)512) <<
-      //       32; base_desc |= 2llu << 62; // set wgmma_swizzle mode
-      //   }
-      //   else if constexpr (SMEM::b == 1) {
-      //       base_desc |= matrix_descriptor_encode((uint64_t)512*ST::height)
-      //       << 16; base_desc |= matrix_descriptor_encode((uint64_t)256) <<
-      //       32; base_desc |= 3llu << 62; // set wgmma_swizzle mode
-      //   }
-      //   else {
-      //       base_desc |= matrix_descriptor_encode((uint64_t)256) << 16;
-      //       base_desc |= matrix_descriptor_encode((uint64_t)128) << 32;
-      //       base_desc |= 0llu << 62; // set wgmma_swizzle mode
-      //   }
     }
   }
 

--- a/include/mirage/persistent_kernel/tasks/smem_layout.cuh
+++ b/include/mirage/persistent_kernel/tasks/smem_layout.cuh
@@ -139,6 +139,10 @@ struct smem_col {
 
   using value_type = T;
 
+  static constexpr int b = B;
+  static constexpr int m = M;
+  static constexpr int s = S;
+
   static constexpr size_t ROW = ROW_;
   static constexpr size_t COL = COL_;
 

--- a/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
+++ b/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
@@ -12,129 +12,130 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "bfloat16.h"
-#include "hopper/matmul_demo_hopper.cuh"
-#include <cuda_runtime.h>
-#include <torch/extension.h>
-// create tma
-using kernel::linear_kernel_hopper;
-using bfloat16 = type::bfloat16_t;
-
-template <typename T,
-          int BATCH_SIZE,
-          int OUTPUT_SIZE,
-          int REDUCTION_SIZE,
-          typename TMA_A,
-          typename TMA_B,
-          typename TMA_OUT,
-          int Kstages = 2>
-__global__ void
-    linear_kernel_hopper_wrapper(void *output_ptr,
-                                 const __grid_constant__ TMA_A tma_a,
-                                 const __grid_constant__ TMA_B tma_b,
-                                 const __grid_constant__ TMA_OUT tma_out) {
-  linear_kernel_hopper<T,
-                       BATCH_SIZE,
-                       OUTPUT_SIZE,
-                       REDUCTION_SIZE,
-                       Kstages,
-                       TMA_A,
-                       TMA_B,
-                       TMA_OUT>(output_ptr, tma_a, tma_b, tma_out);
-}
-
-
-template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
-void launch_linear_hopper(
-  void *input_ptr,
-  void *weight_ptr,
-  void *output_ptr) {
-
-  using TMA_A = kernel::tma::tma<bfloat16, 0, 0, 0, BATCH_SIZE, REDUCTION_SIZE, BATCH_SIZE, 64, true>;
-  using TMA_B = kernel::tma::tma<bfloat16, 0, 0, 0, OUTPUT_SIZE, REDUCTION_SIZE, OUTPUT_SIZE, 64, true>;
-
-  using TMA_OUT = kernel::tma::tma<bfloat16, 0, 0, 0, BATCH_SIZE, OUTPUT_SIZE, BATCH_SIZE, 64, true>;
-
-  TMA_A tma_a(input_ptr);
-  TMA_B tma_b(weight_ptr);
-  TMA_OUT tma_out(output_ptr);
-
-  // printf("1\n");
-  // printf("input_ptr: %p, weight_ptr: %p, output_ptr: %p\n", input_ptr, weight_ptr, output_ptr);
-
-  dim3 grid_dim(1, 1, 1);
-  dim3 block_dim(256, 1, 1);
-  size_t smem_size = 88888;
-  cudaFuncSetAttribute(
-      linear_kernel_hopper_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE, TMA_A, TMA_B, TMA_OUT>,
-      cudaFuncAttributeMaxDynamicSharedMemorySize,
-      smem_size);
-
-
-  linear_kernel_hopper_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE, TMA_A, TMA_B, TMA_OUT>
-      <<<grid_dim, block_dim, smem_size>>>(
-          output_ptr, tma_a, tma_b, tma_out);
-}
-
-#define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE) \
-  case REDUCTION_SIZE: \
-    launch_linear_hopper<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(input_ptr, weight_ptr, output_ptr); \
-    break;
-
-#define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE) \
-  switch (input.size(1)) { \
-    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128) \
-    default: \
-      printf("Unsupported reduction size in test: %zu\n", input.size(1)); \
-      break; \
-  }
-
-#define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE) \
-  case OUTPUT_SIZE: \
-    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE) \
-    break;
-
-
-#define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE) \
-  switch (output.size(0)) { \
-    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 16) \
-    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32) \
-    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64) \
-    default: \
-      printf("Unsupported output size in test: %zu\n", output.size(1)); \
-      break; \
-  }
-
-#define DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE) \
-  case BATCH_SIZE: \
-    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE) \
-    break;
-
-
-void linear_kernel(torch::Tensor input,
-                   torch::Tensor weight,
-                   torch::Tensor output) {
-
-  void *input_ptr = input.data_ptr();
-  void *weight_ptr = weight.data_ptr();
-  void *output_ptr = output.data_ptr();
-
-  printf("1\n");
-
-  switch (input.size(0)) {
-    DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
-    default:
-      printf("Unsupported output size in test: %zu\n", output.size(0));
-      break;
-  }
-  
-
-  cudaError_t err = cudaDeviceSynchronize();
-  if (err != cudaSuccess) {
-    printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
-  }
-}
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("linear", &linear_kernel, "Linear kernel");
-}
+ #include "bfloat16.h"
+ #include "hopper/matmul_demo_hopper.cuh"
+ #include <cuda_runtime.h>
+ #include <torch/extension.h>
+ // create tma
+ using kernel::linear_kernel_hopper;
+ using bfloat16 = type::bfloat16_t;
+ 
+ template <typename T,
+           int BATCH_SIZE,
+           int OUTPUT_SIZE,
+           int REDUCTION_SIZE,
+           typename TMA_A,
+           typename TMA_B,
+           typename TMA_OUT,
+           int Kstages = 2>
+ __global__ void
+     linear_kernel_hopper_wrapper(void *output_ptr,
+                                  const __grid_constant__ TMA_A tma_a,
+                                  const __grid_constant__ TMA_B tma_b,
+                                  const __grid_constant__ TMA_OUT tma_out) {
+   linear_kernel_hopper<T,
+                        BATCH_SIZE,
+                        OUTPUT_SIZE,
+                        REDUCTION_SIZE,
+                        Kstages,
+                        TMA_A,
+                        TMA_B,
+                        TMA_OUT>(output_ptr, tma_a, tma_b, tma_out);
+ }
+ 
+ 
+ template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+ void launch_linear_hopper(
+   void *input_ptr,
+   void *weight_ptr,
+   void *output_ptr) {
+ 
+ 
+  //  printf("1\n");
+ 
+   using TMA_A = kernel::tma::tma<bfloat16, 0, 4, 3, BATCH_SIZE, REDUCTION_SIZE, BATCH_SIZE, 16, true>;
+   using TMA_B = kernel::tma::tma<bfloat16, 0, 4, 3, OUTPUT_SIZE, REDUCTION_SIZE, OUTPUT_SIZE, 16, true>;
+ 
+   using TMA_OUT = kernel::tma::tma<bfloat16, 0, 4, 3, BATCH_SIZE, OUTPUT_SIZE, BATCH_SIZE, 64, true>;
+ 
+   TMA_A tma_a(input_ptr);
+   TMA_B tma_b(weight_ptr);
+   TMA_OUT tma_out(output_ptr);
+ 
+  //  printf("1\n");
+   // printf("input_ptr: %p, weight_ptr: %p, output_ptr: %p\n", input_ptr, weight_ptr, output_ptr);
+ 
+   dim3 grid_dim(1, 1, 1);
+   dim3 block_dim(256, 1, 1);
+   size_t smem_size = 88888;
+   cudaFuncSetAttribute(
+       linear_kernel_hopper_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE, TMA_A, TMA_B, TMA_OUT>,
+       cudaFuncAttributeMaxDynamicSharedMemorySize,
+       smem_size);
+ 
+ 
+   linear_kernel_hopper_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE, TMA_A, TMA_B, TMA_OUT>
+       <<<grid_dim, block_dim, smem_size>>>(
+           output_ptr, tma_a, tma_b, tma_out);
+ }
+ 
+ #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE) \
+   case REDUCTION_SIZE: \
+     launch_linear_hopper<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(input_ptr, weight_ptr, output_ptr); \
+     break;
+ 
+ #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE) \
+   switch (input.size(1)) { \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128) \
+     default: \
+       printf("Unsupported reduction size in test: %zu\n", input.size(1)); \
+       break; \
+   }
+ 
+ #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE) \
+   case OUTPUT_SIZE: \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE) \
+     break;
+ 
+ 
+ #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE) \
+   switch (output.size(1)) { \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64) \
+     default: \
+       printf("Unsupported output size in test: %zu\n", output.size(1)); \
+       break; \
+   }
+ 
+ #define DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE) \
+   case BATCH_SIZE: \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE) \
+     break;
+ 
+ 
+ void linear_kernel(torch::Tensor input,
+                    torch::Tensor weight,
+                    torch::Tensor output) {
+ 
+   void *input_ptr = input.data_ptr();
+   void *weight_ptr = weight.data_ptr();
+   void *output_ptr = output.data_ptr();
+ 
+  //  printf("1\n");
+ 
+   switch (input.size(0)) {
+     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
+     default:
+       printf("Unsupported output size in test: %zu\n", output.size(0));
+       break;
+   }
+   
+ 
+   cudaError_t err = cudaDeviceSynchronize();
+   if (err != cudaSuccess) {
+     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+   }
+ }
+ 
+ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+   m.def("linear", &linear_kernel, "Linear kernel");
+ }

--- a/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
+++ b/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
@@ -59,8 +59,8 @@ void launch_linear_hopper(
   TMA_B tma_b(weight_ptr);
   TMA_OUT tma_out(output_ptr);
 
-  printf("2\n");
-  printf("TMA_A: %zu, TMA_B: %zu, TMA_OUT: %zu\n", sizeof(TMA_A), sizeof(TMA_B), sizeof(TMA_OUT));
+  // printf("1\n");
+  // printf("input_ptr: %p, weight_ptr: %p, output_ptr: %p\n", input_ptr, weight_ptr, output_ptr);
 
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(256, 1, 1);
@@ -83,7 +83,7 @@ void launch_linear_hopper(
 
 #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE) \
   switch (input.size(1)) { \
-    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096) \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128) \
     default: \
       printf("Unsupported reduction size in test: %zu\n", input.size(1)); \
       break; \

--- a/tests/runtime_python/hopper/test_matmul_hopper.py
+++ b/tests/runtime_python/hopper/test_matmul_hopper.py
@@ -1,14 +1,21 @@
 import torch
 import runtime_kernel_hopper
 
+torch.set_printoptions(sci_mode=False)
 
-# input = torch.randn(64, 4096, dtype=torch.bfloat16, device='cuda')
-# weight = torch.randn(4096, 64, dtype=torch.bfloat16, device='cuda')
+# reduction_size = 4096
+# output_sizes = [16, 32, 64]
+reduction_size = 4096
+output_sizes = [32]
 
-input = torch.full((64, 64),0.1,  dtype=torch.bfloat16, device='cuda')
-weight = torch.full((64, 64), 0.1, dtype=torch.bfloat16, device='cuda')
-output = torch.empty(64, 64, dtype=torch.bfloat16, device='cuda')
+for output_size in output_sizes:
+    print(f"\n=== Testing output_size = {output_size} ===")
+    x = torch.randn((64, reduction_size), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((output_size, reduction_size), device="cuda", dtype=torch.bfloat16)
+    output = torch.empty(64, output_size, device="cuda", dtype=torch.bfloat16)
 
-runtime_kernel_hopper.linear(input, weight, output)
-print(output)
-# print(torch.matmul(input, weight))
+    runtime_kernel_hopper.linear(x, w, output)
+    torch_out = torch.matmul(x, torch.transpose(w, 0, 1))
+
+    print("Ratio (kernel / torch):")
+    print(output / torch_out)

--- a/tests/runtime_python/hopper/test_matmul_hopper.py
+++ b/tests/runtime_python/hopper/test_matmul_hopper.py
@@ -5,7 +5,7 @@ torch.set_printoptions(sci_mode=False)
 
 # reduction_size = 4096
 # output_sizes = [16, 32, 64]
-reduction_size = 4096
+reduction_size = 128
 output_sizes = [64]
 
 for output_size in output_sizes:
@@ -14,7 +14,13 @@ for output_size in output_sizes:
     w = torch.ones((output_size, reduction_size), device="cuda", dtype=torch.bfloat16)
     output = torch.empty(64, output_size, device="cuda", dtype=torch.bfloat16)
 
-    x[0, 0] = 0
+    for i in range(64):
+        for j in range(reduction_size):
+            x[i, j] = 1 + (i * reduction_size + j) * 1
+    
+    for i in range(output_size):
+        for j in range(reduction_size):
+            w[i, j] = 1 + (i * reduction_size + j) * 1
 
     runtime_kernel_hopper.linear(x, w, output)
     torch_out = torch.matmul(x, torch.transpose(w, 0, 1))
@@ -23,6 +29,11 @@ for output_size in output_sizes:
     print(torch_out)
     print("output.shape", output.shape)
     print(output)
+
+    # print all of x
+    print("x.shape", x.shape)
+    print(x)
+
 
     print("Ratio (kernel / torch):")
     print(output / torch_out)

--- a/tests/runtime_python/hopper/test_matmul_hopper.py
+++ b/tests/runtime_python/hopper/test_matmul_hopper.py
@@ -6,16 +6,23 @@ torch.set_printoptions(sci_mode=False)
 # reduction_size = 4096
 # output_sizes = [16, 32, 64]
 reduction_size = 4096
-output_sizes = [32]
+output_sizes = [64]
 
 for output_size in output_sizes:
     print(f"\n=== Testing output_size = {output_size} ===")
-    x = torch.randn((64, reduction_size), device="cuda", dtype=torch.bfloat16)
-    w = torch.randn((output_size, reduction_size), device="cuda", dtype=torch.bfloat16)
+    x = torch.ones((64, reduction_size), device="cuda", dtype=torch.bfloat16)
+    w = torch.ones((output_size, reduction_size), device="cuda", dtype=torch.bfloat16)
     output = torch.empty(64, output_size, device="cuda", dtype=torch.bfloat16)
+
+    x[0, 0] = 0
 
     runtime_kernel_hopper.linear(x, w, output)
     torch_out = torch.matmul(x, torch.transpose(w, 0, 1))
+
+    print("torch_out.shape", torch_out.shape)
+    print(torch_out)
+    print("output.shape", output.shape)
+    print(output)
 
     print("Ratio (kernel / torch):")
     print(output / torch_out)

--- a/tests/runtime_python/hopper/test_matmul_hopper.py
+++ b/tests/runtime_python/hopper/test_matmul_hopper.py
@@ -1,7 +1,7 @@
 import torch
 import runtime_kernel_hopper
 
-torch.set_printoptions(sci_mode=False)
+torch.set_printoptions(sci_mode=False, profile="full")
 
 # reduction_size = 4096
 # output_sizes = [16, 32, 64]
@@ -16,11 +16,14 @@ for output_size in output_sizes:
 
     for i in range(64):
         for j in range(reduction_size):
-            x[i, j] = 1 + (i * reduction_size + j) * 1
+            x[i, j] = 0.1
     
     for i in range(output_size):
         for j in range(reduction_size):
-            w[i, j] = 1 + (i * reduction_size + j) * 1
+            w[i, j] = 0.1
+
+    x[7, 0] = 0.2
+    # x[0, 0] = 0.2
 
     runtime_kernel_hopper.linear(x, w, output)
     torch_out = torch.matmul(x, torch.transpose(w, 0, 1))
@@ -31,9 +34,9 @@ for output_size in output_sizes:
     print(output)
 
     # print all of x
-    print("x.shape", x.shape)
-    print(x)
+    # print("x.shape", x.shape)
+    # print(x)
 
 
-    print("Ratio (kernel / torch):")
-    print(output / torch_out)
+    # print("Ratio (kernel / torch):")
+    # print(output / torch_out)

--- a/tests/runtime_python/hopper/test_matmul_hopper.py
+++ b/tests/runtime_python/hopper/test_matmul_hopper.py
@@ -22,7 +22,7 @@ for output_size in output_sizes:
         for j in range(reduction_size):
             w[i, j] = 0.1
 
-    x[7, 0] = 0.2
+    x[2, 127] = 0.2
     # x[0, 0] = 0.2
 
     runtime_kernel_hopper.linear(x, w, output)

--- a/tests/runtime_python/setup.py
+++ b/tests/runtime_python/setup.py
@@ -20,6 +20,7 @@ setup(
                 'nvcc': [
                     '-O3',
                     '-gencode=arch=compute_80,code=sm_80',
+                    '-gencode=arch=compute_90a,code=sm_90a',
                 ]
             }
         )


### PR DESCRIPTION
**Description of changes:**
This PR aims to support multiple combinations of ```BATCH_SIZE```, ```REDUCTION_SIZE``` and ```OUTPUT_SIZE``` for matmul hopper kernels.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


